### PR TITLE
Make running of backends more solid

### DIFF
--- a/bin/yaml-editor.sh
+++ b/bin/yaml-editor.sh
@@ -4,6 +4,15 @@ set -e
 
 file=test.yaml
 
+if [[ $1 == CHECK ]]; then
+  cd /tmp/yaml-editor
+  while [[ ! -e DONE ]]; do
+    sleep 0.05
+  done
+  rm DONE
+  exit 0
+fi
+
 if [[ $# -gt 0 ]]; then
   export RUN_LIST="$@"
   root="$(cd $(dirname $0)/..; pwd)"
@@ -55,3 +64,5 @@ fi
 for yaml in $RUN_LIST; do
   cat $file | $yaml &> $yaml.out || true
 done
+
+touch DONE

--- a/share/vimrc
+++ b/share/vimrc
@@ -1,5 +1,5 @@
 set autoread exrc
-map ` :w<BAR>!sleep .3<CR><CR>
+map ` :w<BAR>!yaml-editor.sh CHECK<CR><CR>
 map Q :qa!<CR>
 map S :w SAVE<CR>
 map C ggVGdi


### PR DESCRIPTION
Currently we run the backends and wait .3 seconds. We should do this in a more
exacting way. We could run them all in the background and wait on the PIDs. Or
maybe something easier.
