### PR TITLE
perl6-p6/json: Prevent time consuming dump of Failure object

### DIFF
--- a/sbin/perl6-json
+++ b/sbin/perl6-json
@@ -5,5 +5,9 @@ use YAMLish;
 use JSON::Tiny;
 
 for load-yamls(slurp) -> $doc {
+    if ($doc ~~ Failure) {
+        note $doc;
+        exit 1;
+    }
     say to-json $doc;
 }

--- a/sbin/perl6-p6
+++ b/sbin/perl6-p6
@@ -5,5 +5,9 @@ use YAMLish;
 use Data::Dump;
 
 for load-yamls(slurp) -> $doc {
+    if ($doc ~~ Failure) {
+        note $doc;
+        exit 1;
+    }
     say Dump $doc, :color(False);
 }


### PR DESCRIPTION
Just output Failure object as a string will output the actual error message.