### PR TITLE
Support NimYAML's event output

### DIFF
--- a/docker/bin/nim-compile
+++ b/docker/bin/nim-compile
@@ -9,7 +9,7 @@ yes | nimble install nimyaml
 mkdir -p /work/build/root
 cp -r /root/.nimble /work/build/root/.nimble
 
-nim c /work/yaml-editor/docker/$source
+nim c -d:yamlScalarRepInd /work/yaml-editor/docker/$source
 mv /work/yaml-editor/docker/${source%.nim} /work/$target
 rm -fr /work/yaml-editor/docker/src/nimcache
 

--- a/docker/src/nimyaml_event.nim
+++ b/docker/src/nimyaml_event.nim
@@ -1,12 +1,9 @@
-import yaml/stream, yaml/parser, yaml/taglib, streams
+import yaml/stream, yaml/parser, streams
 
 var
-  tags = initExtendedTagLibrary()
-  p = newYamlParser(tags)
-  yaml = newFileStream(stdin)
-  events = p.parse(yaml)
-  output = ""
+  p = newYamlParser()
+  events = p.parse(newFileStream(stdin))
 
-for event in events: output.add($event & "\n")
-
-stdout.write(output)
+echo "+STR"
+for event in events: echo event
+echo "-STR"

--- a/docker/src/nimyaml_event.nim
+++ b/docker/src/nimyaml_event.nim
@@ -5,5 +5,5 @@ var
   events = p.parse(newFileStream(stdin))
 
 echo "+STR"
-for event in events: echo event
+for event in events: echo p.display(event)
 echo "-STR"


### PR DESCRIPTION
* We don't need the tag library
* instead of creating a `FileStream` to `stdout`, we can directly use `echo`
* output `+STR` and `-STR` at beginning and end of the stream respectively
* variable name `yaml` conflicts with module name and has therefore been removed