### PR TITLE
YAML::PP: utf8 encode output

### DIFF
--- a/sbin/perl5-pp-event
+++ b/sbin/perl5-pp-event
@@ -3,10 +3,13 @@ use strict;
 use warnings;
 use 5.010;
 
+use Encode;
+
 use YAML::PP::Parser;
 my $parser = YAML::PP::Parser->new(
   receiver => sub {
     my ($self, $event, $content) = @_;
+    $content = encode_utf8($content) if defined $content;
     say defined $content ? "$event $content" : $event;
   },
 );


### PR DESCRIPTION
Currently it outputs a warning when printing utf8 decoded data

