### PR TITLE
Add benchmark scripts

### DIFF
--- a/sbin/perl5-pegex-parse-bench
+++ b/sbin/perl5-pegex-parse-bench
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use 5.010;
+
+use lib '/yaml-pegex-pm/lib';
+
+use Pegex;
+use YAML::Pegex;
+use Pegex::Parser;
+use YAML::Pegex::Grammar;
+use YAML::Pegex::Receiver::Test;
+use Time::HiRes ();
+
+my ($count) = @ARGV;
+$count //= 1;
+
+chomp(my @files = <STDIN>);
+my @yaml = map {
+    open my $fh, "<", $_ or die $!;
+    my $yaml = do { local $/; <$fh> };
+    close $fh;
+    [ $_, $yaml ];
+} @files;
+
+my $start = Time::HiRes::time;
+for (1 .. $count) {
+
+    for my $item (@yaml) {
+
+        my $parser = Pegex::Parser->new(
+            grammar => YAML::Pegex::Grammar->new,
+            receiver => YAML::Pegex::Receiver::Test->new,
+            #maxparse => 10000,
+        );
+
+        my ($file, $yaml) = @$item;
+
+        my @events = eval { @{$parser->parse($yaml)} };
+        if ($@) {
+            warn "ERROR ($file): $@";
+        }
+    }
+
+}
+my $elapsed = Time::HiRes::time - $start;
+say $elapsed * 1000;

--- a/sbin/perl5-pegex-parse-bench
+++ b/sbin/perl5-pegex-parse-bench
@@ -36,10 +36,7 @@ for (1 .. $count) {
 
         my ($file, $yaml) = @$item;
 
-        my @events = eval { @{$parser->parse($yaml)} };
-        if ($@) {
-            warn "ERROR ($file): $@";
-        }
+        $parser->parse($yaml);
     }
 
 }

--- a/sbin/perl5-pegex-parse-bench
+++ b/sbin/perl5-pegex-parse-bench
@@ -23,16 +23,16 @@ my @yaml = map {
     [ $_, $yaml ];
 } @files;
 
+my $parser = Pegex::Parser->new(
+    grammar => YAML::Pegex::Grammar->new,
+    receiver => YAML::Pegex::Receiver::Test->new,
+    #maxparse => 10000,
+);
+
 my $start = Time::HiRes::time;
 for (1 .. $count) {
 
     for my $item (@yaml) {
-
-        my $parser = Pegex::Parser->new(
-            grammar => YAML::Pegex::Grammar->new,
-            receiver => YAML::Pegex::Receiver::Test->new,
-            #maxparse => 10000,
-        );
 
         my ($file, $yaml) = @$item;
 

--- a/sbin/perl5-pm-load-bench
+++ b/sbin/perl5-pm-load-bench
@@ -1,0 +1,31 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use 5.010;
+
+use YAML;
+use Time::HiRes ();
+$YAML::Numify = 1;
+
+my ($count) = @ARGV;
+$count //= 1;
+
+chomp(my @files = <STDIN>);
+my @yaml = map {
+    open my $fh, "<", $_ or die $!;
+    my $yaml = do { local $/; <$fh> };
+    close $fh;
+    [ $_, $yaml ];
+} @files;
+
+my $start = Time::HiRes::time;
+for (1 .. $count) {
+
+    for my $item (@yaml) {
+        my ($file, $yaml) = @$item;
+        my $data = eval { Load $yaml };
+    }
+
+}
+my $elapsed = Time::HiRes::time - $start;
+say $elapsed * 1000;

--- a/sbin/perl5-pm-load-bench
+++ b/sbin/perl5-pm-load-bench
@@ -23,7 +23,7 @@ for (1 .. $count) {
 
     for my $item (@yaml) {
         my ($file, $yaml) = @$item;
-        my $data = eval { Load $yaml };
+        my $data = Load $yaml;
     }
 
 }

--- a/sbin/perl5-pp-load-bench
+++ b/sbin/perl5-pp-load-bench
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use 5.010;
+
+use YAML::PP::Loader;
+use Time::HiRes ();
+
+my ($count) = @ARGV;
+$count //= 1;
+
+chomp(my @files = <STDIN>);
+my @yaml = map {
+    open my $fh, "<", $_ or die $!;
+    my $yaml = do { local $/; <$fh> };
+    close $fh;
+    [ $_, $yaml ];
+} @files;
+
+my $start = Time::HiRes::time;
+for (1 .. $count) {
+
+    for my $item (@yaml) {
+        my ($file, $yaml) = @$item;
+        my @docs = YAML::PP::Loader->new(boolean => 'perl')->load($yaml);
+    }
+
+}
+my $elapsed = Time::HiRes::time - $start;
+say $elapsed * 1000;

--- a/sbin/perl5-pp-load-bench
+++ b/sbin/perl5-pp-load-bench
@@ -17,12 +17,14 @@ my @yaml = map {
     [ $_, $yaml ];
 } @files;
 
+my $loader = YAML::PP::Loader->new(boolean => 'perl');
+
 my $start = Time::HiRes::time;
 for (1 .. $count) {
 
     for my $item (@yaml) {
         my ($file, $yaml) = @$item;
-        my @docs = YAML::PP::Loader->new(boolean => 'perl')->load($yaml);
+        my @docs = $loader->load($yaml);
     }
 
 }

--- a/sbin/perl5-pp-parse-bench
+++ b/sbin/perl5-pp-parse-bench
@@ -1,0 +1,36 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use 5.010;
+
+use YAML::PP::Parser;
+use Time::HiRes ();
+
+my ($count) = @ARGV;
+$count //= 1;
+
+chomp(my @files = <STDIN>);
+my @yaml = map {
+    open my $fh, "<", $_ or die $!;
+    my $yaml = do { local $/; <$fh> };
+    close $fh;
+    [ $_, $yaml ];
+} @files;
+
+my $start = Time::HiRes::time;
+my $parser = YAML::PP::Parser->new(
+    receiver => sub {
+        my ($self, $event, $content) = @_;
+    },
+);
+for (1 .. $count) {
+
+    for my $item (@yaml) {
+        my ($file, $yaml) = @$item;
+
+        eval { $parser->parse($yaml) };
+    }
+
+}
+my $elapsed = Time::HiRes::time - $start;
+say $elapsed * 1000;

--- a/sbin/perl5-pp-parse-bench
+++ b/sbin/perl5-pp-parse-bench
@@ -28,7 +28,7 @@ for (1 .. $count) {
     for my $item (@yaml) {
         my ($file, $yaml) = @$item;
 
-        eval { $parser->parse($yaml) };
+        $parser->parse($yaml);
     }
 
 }

--- a/sbin/perl5-syck-load-bench
+++ b/sbin/perl5-syck-load-bench
@@ -24,7 +24,7 @@ for (1 .. $count) {
 
     for my $item (@yaml) {
         my ($file, $yaml) = @$item;
-        my $data = eval { Load $yaml };
+        my $data = Load $yaml;
     }
 
 }

--- a/sbin/perl5-syck-load-bench
+++ b/sbin/perl5-syck-load-bench
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use 5.010;
+
+use Data::Dumper;
+use YAML::Syck;
+$YAML::Syck::ImplicitTyping = 1;
+use Time::HiRes ();
+
+my ($count) = @ARGV;
+$count //= 1;
+
+chomp(my @files = <STDIN>);
+my @yaml = map {
+    open my $fh, "<", $_ or die $!;
+    my $yaml = do { local $/; <$fh> };
+    close $fh;
+    [ $_, $yaml ];
+} @files;
+
+my $start = Time::HiRes::time;
+for (1 .. $count) {
+
+    for my $item (@yaml) {
+        my ($file, $yaml) = @$item;
+        my $data = eval { Load $yaml };
+    }
+
+}
+my $elapsed = Time::HiRes::time - $start;
+say $elapsed * 1000;

--- a/sbin/perl5-tiny-load-bench
+++ b/sbin/perl5-tiny-load-bench
@@ -1,0 +1,31 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use 5.010;
+
+use Data::Dumper;
+use YAML::Tiny;
+use Time::HiRes ();
+
+my ($count) = @ARGV;
+$count //= 1;
+
+chomp(my @files = <STDIN>);
+my @yaml = map {
+    open my $fh, "<", $_ or die $!;
+    my $yaml = do { local $/; <$fh> };
+    close $fh;
+    [ $_, $yaml ];
+} @files;
+
+my $start = Time::HiRes::time;
+for (1 .. $count) {
+
+    for my $item (@yaml) {
+        my ($file, $yaml) = @$item;
+        my $data = eval { Load $yaml };
+    }
+
+}
+my $elapsed = Time::HiRes::time - $start;
+say $elapsed * 1000;

--- a/sbin/perl5-tiny-load-bench
+++ b/sbin/perl5-tiny-load-bench
@@ -23,7 +23,7 @@ for (1 .. $count) {
 
     for my $item (@yaml) {
         my ($file, $yaml) = @$item;
-        my $data = eval { Load $yaml };
+        my $data = Load $yaml;
     }
 
 }

--- a/sbin/perl5-xs-load-bench
+++ b/sbin/perl5-xs-load-bench
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use 5.010;
+
+use YAML::XS;
+use Time::HiRes ();
+
+my ($count) = @ARGV;
+$count //= 1;
+
+chomp(my @files = <STDIN>);
+my @yaml = map {
+    open my $fh, "<", $_ or die $!;
+    my $yaml = do { local $/; <$fh> };
+    close $fh;
+    [ $_, $yaml ];
+} @files;
+
+my $start = Time::HiRes::time;
+for (1 .. $count) {
+
+    for my $item (@yaml) {
+        my ($file, $yaml) = @$item;
+        my $data = eval { YAML::XS::Load $yaml };
+    }
+
+}
+my $elapsed = Time::HiRes::time - $start;
+say $elapsed * 1000;

--- a/sbin/perl5-xs-load-bench
+++ b/sbin/perl5-xs-load-bench
@@ -22,7 +22,7 @@ for (1 .. $count) {
 
     for my $item (@yaml) {
         my ($file, $yaml) = @$item;
-        my $data = eval { YAML::XS::Load $yaml };
+        my $data = YAML::XS::Load $yaml;
     }
 
 }

--- a/sbin/pyyaml-parse-bench
+++ b/sbin/pyyaml-parse-bench
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+import sys
+import pprint
+import yaml
+import time
+
+count = sys.argv[1]
+
+filenames = sys.stdin.readlines()
+filenames = [x.strip() for x in filenames]
+content = []
+for file in filenames:
+    with open(file) as f:
+        string = f.read()
+        content.append([file, string])
+
+start = time.time()
+
+for i in range(0, int(count)):
+
+    for item in content:
+        string = item[1]
+        for event in yaml.parse(string):
+            next
+
+end = time.time()
+elapsed = (end - start) * 1000
+print("%f" % elapsed)

--- a/sbin/ruamel-parse-bench
+++ b/sbin/ruamel-parse-bench
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+import sys
+import pprint
+import time
+import ruamel.yaml
+
+count = sys.argv[1]
+
+filenames = sys.stdin.readlines()
+filenames = [x.strip() for x in filenames]
+content = []
+for file in filenames:
+    with open(file) as f:
+        string = f.read()
+        content.append([file, string])
+
+start = time.time()
+
+for i in range(0, int(count)):
+
+    for item in content:
+        string = item[1]
+        for event in ruamel.yaml.parse(string):
+            next
+
+end = time.time()
+elapsed = (end - start) * 1000
+print("%f" % elapsed)

--- a/sbin/ruby-load-bench
+++ b/sbin/ruby-load-bench
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'yaml'
+
+count = ARGV[0].to_i
+
+filenames = $stdin.readlines.map { |f| f.chomp }
+contents = filenames.map {
+    |f|
+    file = File.new(f, "r")
+    file.read
+}
+
+startTime = Time.now
+
+(1 .. count).each { |i|
+    contents.each { |yaml|
+#        puts "yaml: '#{yaml}'"
+        YAML.load_stream(yaml).each do |doc|
+#          puts JSON.dump doc
+        end
+    }
+}
+endTime = Time.now
+elapsed = (endTime - startTime) * 1000
+puts elapsed


### PR DESCRIPTION
So far I have written the following benchmark scripts:

perl5-pegex-parse-bench
perl5-pm-load-bench
perl5-pp-parse-bench
perl5-syck-load-bench
perl5-tiny-load-bench
perl5-xs-load-bench
pyyaml-parse-bench
ruamel-parse-bench
ruby-load-bench

These take a list of files via STDIN and an iteration count as the
first argument.
They output the runtime in milliseconds (excluding the time for reading the files).



