### PR TITLE
Respect BOM in the incoming stream of bytes for Java

### DIFF
--- a/docker/src/java/src/main/java/org/yaml/editor/Snake2Events.java
+++ b/docker/src/java/src/main/java/org/yaml/editor/Snake2Events.java
@@ -2,6 +2,7 @@ package org.yaml.editor;
 
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.events.*;
+import org.yaml.snakeyaml.reader.UnicodeReader;
 
 import java.io.*;
 import java.util.HashMap;
@@ -106,7 +107,7 @@ public class Snake2Events {
 
     void yamlToEvents(final InputStream in, final Writer out) throws IOException {
         final Yaml yaml = new Yaml();
-        for (final Event event: yaml.parse(new InputStreamReader(in))) {
+        for (final Event event: yaml.parse(new UnicodeReader(in))) {
             out.write(renderers.get(event.getClass()).write(event));
             out.write('\n');
         }


### PR DESCRIPTION
Respect BOM as defined in the 1.1 spec for Java (UTF-32 is not used)