### PR TITLE
 Add js.event, js.json & js.yaml, using JS `yaml` package

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,6 +1,7 @@
 /build
 /cjson
 /HsYAML
+/js
 /js-yaml
 /libyaml
 /lua-yaml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,28 +1,28 @@
 FROM ubuntu:16.04
 
 RUN apt-get update \
+ && apt-get install -y curl \
+ && curl -sL https://deb.nodesource.com/setup_8.x | bash \
+ && apt-get install -y nodejs
+RUN apt-get update \
  && apt-get install -y \
+    curl \
     default-jre-headless \
     gist \
     git \
     jq \
     locales \
-    nodejs \
-    npm \
     perl \
     python \
     python-pip \
     ruby \
     vim \
- && ( \
-        ln /usr/bin/nodejs /usr/bin/node \
-        && npm install -g coffee-script \
-    ) \
  && pip install ruamel.yaml \
  && locale-gen en_US.UTF-8 \
+ && curl -sL https://deb.nodesource.com/setup_8.x | bash \
+ && apt-get install -y luajit nodejs \
+ && npm install -g coffee-script \
  && true
-
-RUN apt-get install -y luajit
 
 COPY build/ /
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -18,7 +18,11 @@ LUA_MODULES := \
     build/usr/local/share/lua/5.1/yaml/init.lua \
     build/usr/local/share/lua/5.1/cjson/util.lua
 NIM_BINARIES := build/bin/nimyaml-event
-NODE_MODULES := build/node_modules/js-yaml/lib/js-yaml.js
+NODE_JS_YAML := build/node_modules/js-yaml/lib/js-yaml.js
+NODE_YAML := build/node_modules/yaml/dist/index.js
+NODE_MODULES := \
+    $(NODE_JS_YAML) \
+    $(NODE_YAML)
 PERL5_YAML_PM := build/lib/perl5/YAML.pm
 PERL5_YAML_XS := build/lib/perl5/x86_64-linux-gnu-thread-multi/YAML/LibYAML.pm
 PERL5_YAML_TINY := build/lib/perl5/YAML/Tiny.pm
@@ -123,7 +127,11 @@ $(NIM_BINARIES): src/nimyaml_event.nim NimYAML
 	docker run --rm -v $(BASE):/work $(DOCKER_USER)/builder-nim nim-compile $< $@
 	touch $@
 
-$(NODE_MODULES): js-yaml
+$(NODE_JS_YAML): js-yaml
+	docker run --rm -v $(BASE):/work $(DOCKER_USER)/builder-node node-modules $<
+	touch $@
+
+$(NODE_YAML): js
 	docker run --rm -v $(BASE):/work $(DOCKER_USER)/builder-node node-modules $<
 	touch $@
 
@@ -188,6 +196,9 @@ builder-%: builder
 
 ../../libyaml ../../pyyaml:
 	git clone git@github.com:yaml/$(@:../../%=%) $@
+
+../../js:
+	git clone git@github.com:eemeli/yaml $@
 
 ../../js-yaml:
 	git clone git@github.com:nodeca/$(@:../../%=%) $@

--- a/docker/bin/node-modules
+++ b/docker/bin/node-modules
@@ -2,11 +2,20 @@
 
 set -ex
 
-cd /work/js-yaml/
-npm install .
-rm -fr /work/build/node_modules/
-mv node_modules /work/build/
-
-vcs-info $1
+if [[ $1 =~ js-yaml ]]; then
+  cd /work/js-yaml/
+  npm install .
+  rm -fr /work/build/node_modules/js-yaml
+  cd /work/build/
+  npm install --no-save /work/js-yaml/
+  vcs-info js-yaml
+else
+  cd /work/js/
+  npm install .
+  npm run build
+  cd /work/build/
+  npm install --no-save /work/js/
+  vcs-info js
+fi
 
 set-perms

--- a/docker/bin/node-modules
+++ b/docker/bin/node-modules
@@ -5,16 +5,17 @@ set -ex
 if [[ $1 =~ js-yaml ]]; then
   cd /work/js-yaml/
   npm install .
-  rm -fr /work/build/node_modules/js-yaml
+  npm pack > pack.filename
   cd /work/build/
-  npm install --no-save /work/js-yaml/
+  npm install --no-save "/work/js-yaml/$(cat /work/js-yaml/pack.filename)"
   vcs-info js-yaml
 else
   cd /work/js/
   npm install .
   npm run build
+  npm pack > pack.filename
   cd /work/build/
-  npm install --no-save /work/js/
+  npm install --no-save "/work/js/$(cat /work/js/pack.filename)"
   vcs-info js
 fi
 

--- a/docker/builder-node.dockerfile
+++ b/docker/builder-node.dockerfile
@@ -1,6 +1,6 @@
 FROM builder
 
-RUN apt-get install -y \
-        nodejs \
-        npm \
- && true
+RUN apt-get update \
+ && apt-get install -y curl \
+ && curl -sL https://deb.nodesource.com/setup_8.x | bash \
+ && apt-get install -y nodejs

--- a/note/Languages
+++ b/note/Languages
@@ -43,6 +43,7 @@
 - Java
   - https://bitbucket.org/asomov/snakeyaml
 - JavaScript
+  - https://eemeli.org/yaml/
   - https://nodeca.github.io/js-yaml/
   - https://github.com/connec/yaml-js
   - https://github.com/stephank/yaml.node

--- a/sbin/js-event
+++ b/sbin/js-event
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const testEvents = require('yaml/dist/test-events').default
+
+const src = fs.readFileSync('/dev/stdin').toString()
+const { events, error } = testEvents(src)
+fs.writeSync(1, events.join('\n') + '\n')
+if (error) {
+  fs.writeSync(2, error.message)
+  process.exit(1)
+}

--- a/sbin/js-json
+++ b/sbin/js-json
@@ -4,7 +4,7 @@ const fs = require('fs')
 const YAML = require('yaml').default
 
 const src = fs.readFileSync('/dev/stdin').toString()
-const docs = YAML.parseDocuments(src).map(doc => {
+const docs = YAML.parseAllDocuments(src).map(doc => {
   if (doc.errors.length !== 0) throw doc.errors[0]
   return JSON.stringify(doc.toJSON(), null, 2) + '\n'
 })

--- a/sbin/js-json
+++ b/sbin/js-json
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const YAML = require('yaml').default
+
+const src = fs.readFileSync('/dev/stdin').toString()
+const docs = YAML.parseDocuments(src).map(doc => {
+  if (doc.errors.length !== 0) throw doc.errors[0]
+  return JSON.stringify(doc.toJSON(), null, 2) + '\n'
+})
+fs.writeSync(1, docs.join(''))

--- a/sbin/js-yaml
+++ b/sbin/js-yaml
@@ -4,7 +4,7 @@ const fs = require('fs')
 const YAML = require('yaml').default
 
 const src = fs.readFileSync('/dev/stdin').toString()
-const docs = YAML.parseDocuments(src).map(doc => {
+const docs = YAML.parseAllDocuments(src).map(doc => {
   if (doc.errors.length !== 0) throw doc.errors[0]
   return String(doc)
 })

--- a/sbin/js-yaml
+++ b/sbin/js-yaml
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const YAML = require('yaml').default
+
+const src = fs.readFileSync('/dev/stdin').toString()
+const docs = YAML.parseDocuments(src).map(doc => {
+  if (doc.errors.length !== 0) throw doc.errors[0]
+  return String(doc)
+})
+fs.writeSync(1, docs.join('...\n'))

--- a/share/emitters.csv
+++ b/share/emitters.csv
@@ -2,6 +2,8 @@ id,reponame,output
 cpp-event,jbeder/yaml-cpp,event
 hs-yaml-event,hvr/HsYAML,event
 hs-yaml-json,hvr/HsYAML,json
+js-json,eemeli/yaml,json
+js-yaml,eemeli/yaml,yaml
 js-yaml-json,nodeca/js-yaml,json
 libyaml-event,yaml/libyaml,event
 libyaml-yaml,yaml/libyaml,yaml

--- a/share/emitters.csv
+++ b/share/emitters.csv
@@ -2,6 +2,7 @@ id,reponame,output
 cpp-event,jbeder/yaml-cpp,event
 hs-yaml-event,hvr/HsYAML,event
 hs-yaml-json,hvr/HsYAML,json
+js-event,eemeli/yaml,event
 js-json,eemeli/yaml,json
 js-yaml,eemeli/yaml,yaml
 js-yaml-json,nodeca/js-yaml,json

--- a/share/frameworks.csv
+++ b/share/frameworks.csv
@@ -1,6 +1,7 @@
 repo,language,name,provider
 Perl-Toolchain-Gang/YAML-Tiny,perl5,YAML::Tiny,github
 asomov/snakeyaml,java,SnakeYAML,bitbucket
+eemeli/yaml,js,yaml,github
 flyx/NimYAML,nim,NimYAML,github
 hvr/HsYAML,haskell,HsYAML,github
 ingydotnet/yaml-libyaml-pm,perl5,YAML::XS,github


### PR DESCRIPTION
This adds [`yaml`](https://eemeli.org/yaml/) to the editor. Its JS package is currently installable with `npm install yaml`, but I've here followed the pattern of other packages and built it from source. It should pass almost all of the applicable test-suite tests, but it's not instrumented (at least yet) for the event format.

As `yaml` requires at least node v6, I've also updated the config to use node v8, the current LTS version that first came out in 2017.

There's a slight naming conflict that this package introduces, as the other JS package is `js-yaml`, and I couldn't figure out a better naming pattern than calling mine just `js`. If you can recommend an alternative, I'd be happy to rename the rules for one or both libraries.