### PR TITLE
Fix Haskell, Java and Perl6 builds

### DIFF
--- a/docker/builder-ghc.dockerfile
+++ b/docker/builder-ghc.dockerfile
@@ -1,4 +1,4 @@
-FROM haskell:8.2.1
+FROM haskell:8.6.5
 
 RUN apt-get update && apt-get install -y pkg-config
 

--- a/docker/builder-perl6.dockerfile
+++ b/docker/builder-perl6.dockerfile
@@ -1,6 +1,6 @@
 FROM builder
 
-RUN wget http://rakudo.org/downloads/star/rakudo-star-2017.04.tar.gz \
+RUN wget http://rakudo.org/dl/star/rakudo-star-2017.04.tar.gz \
  && tar xfz rakudo-star-2017.04.tar.gz \
  && ( \
         cd rakudo-star-2017.04 \

--- a/docker/src/java/src/main/java/org/yaml/editor/Snake2Events.java
+++ b/docker/src/java/src/main/java/org/yaml/editor/Snake2Events.java
@@ -60,7 +60,7 @@ public class Snake2Events {
         private String value(final Event e) {
             final StringBuilder builder = new StringBuilder(" ");
             final ScalarEvent ev = (ScalarEvent) e;
-            builder.append(ev.getStyle().getChar() == null ? ':' : ev.getStyle().getChar());
+            builder.append(ev.getScalarStyle().getChar() == null ? ':' : ev.getScalarStyle().getChar());
             for (char c: ev.getValue().toCharArray()) {
                 switch (c) {
                     case '\b': builder.append("\\b"); break;


### PR DESCRIPTION
This furthers the full monty build in a fresh/from-scratch environment to certain-extent<sup>TM</sup>.. :)

---

The remaining (known) issues are:

* two perl5's modules being broken: yaml-pegex-pm and pegex-pm
  * also the repo's master does not build standalone in a fresh Ubuntu environment, even with these steps (from 2017): https://github.com/ingydotnet/yaml-pegex-pm/issues/2
* after everything builds with `yaml-editor -c` compile command following the docker code path, something in the end tries to build the whole thing again within the docker and it fails with `docker: command not found`. DnD (docker in docker) is possible, but it seems like some unintentional configuration. Steps to repro:

```sh
#!/usr/bin/env sh

git clone https://github.com/yaml/yaml-editor
cd yaml-editor

# apply this patch
curl https://github.com/yaml/yaml-editor/commit/3b34ddb.patch | git apply -v

# source it
. .rc

# disable perl5 in Dockerfile
sed -i '/perl5-modules \\/d' docker/Makefile

# i was also having issue with ssh urls, so i resorted to https:
#
# sed -i 's/git@github\.com:/https:\/\/github\.com\//' docker/Makefile 

# compile
yaml-editor -c
# ^ this build will primarily take place inside docker (unless it is being
#    executed inside a docker; where we can force docker by `mv`ing
#    `/.dockerenv` or inverting the condition at:  `:/bin/yaml-editor#L60`)
#    but git repositories will clone in host (among few other things)

# .... skip spew ... ~5-10 minutes later

make -C docker
make[1]: Entering directory '/yaml-editor/docker'
mkdir -p ../../build/bin
cp ../sbin/* ../../build/bin/
rm -fr build
ln -s ../../build
docker build -t yamlio/builder -f builder.dockerfile .
make[1]: docker: Command not found
Makefile:180: recipe for target 'builder' failed
make[1]: *** [builder] Error 127
make[1]: Leaving directory '/yaml-editor/docker'
Makefile:4: recipe for target 'build' failed
make: *** [build] Error 2
```