### PR TITLE
Explicitly use built-in stat on Mac OS.

### DIFF
--- a/bin/yaml-editor
+++ b/bin/yaml-editor
@@ -46,8 +46,8 @@ fi
 main() {
   input_file=input.yaml
   if [[ $(uname) == Darwin ]]; then
-    uid=$(stat -f%u $0)
-    gid=$(stat -f%g $0)
+    uid=$(/usr/bin/stat -f%u $0)
+    gid=$(/usr/bin/stat -f%g $0)
   else
     uid=$(stat -c%u $0)
     gid=$(stat -c%g $0)


### PR DESCRIPTION
This way, it will work even if a Mac user has GNU stat in their path.